### PR TITLE
Allow filtering of the curated post id

### DIFF
--- a/includes/class-curator.php
+++ b/includes/class-curator.php
@@ -596,7 +596,7 @@ class CUR_Curator extends CUR_Singleton {
 
 				// Do for each post that was found
 				foreach ( $posts as $key => $post ) {
-					$posts[ $key ] = get_post( cur_get_related_id( $post->ID ) );
+					$posts[ $key ] = get_post( apply_filters( 'cur_curated_post_id', cur_get_related_id( $post->ID ) ) );
 				}
 			}
 		}


### PR DESCRIPTION
Allow filtering of the curated post id to make it easier for 3rd party plugins (multilingual plugins for example) to do their magic.

Example use case with [WPML](https://wpml.org/documentation/support/creating-multilingual-wordpress-themes/language-dependent-ids/#2)

```php
add_filter( 'cur_curated_post_id', function ( $id ) {
        return icl_object_id( $id, 'post', true );
} );
```