### PR TITLE
Fix/curated post title

### DIFF
--- a/includes/class-cpt-curator.php
+++ b/includes/class-cpt-curator.php
@@ -221,8 +221,9 @@ class CUR_CPT_Curator extends CUR_Singleton {
 				}
 			}
 
-			// Only run other modules if this post has been curated
+			// Only run this code if this post has been curated
 			if ( false !== $curated_post ) {
+				$this->maybe_update_curated_post( $post );
 				$this->run_modules_on_save( $post );
 			}
 		}
@@ -322,6 +323,28 @@ class CUR_CPT_Curator extends CUR_Singleton {
 			cur_set_item_modules( $set_modules, $curated_post );
 		}
 
+	}
+	
+	/**
+	 * Update curated post title when original post title changes.
+	 *
+	 * @param $post
+	 */
+	function maybe_update_curated_post( $post ) {
+
+		$curated_post = cur_get_curated_post( $post->ID );
+		// Only run other modules if this post has been curated
+		if ( ! $curated_post ) {
+			return;
+		}
+
+		$curated_post_arr = get_post( $curated_post, ARRAY_A );
+
+		if ( $curated_post_arr['post_title'] !== $post->post_title ) {
+			$curated_post_arr['post_title'] = $post->post_title;
+			wp_update_post( $curated_post_arr );
+
+		}
 	}
 
 	/**

--- a/includes/class-cpt-curator.php
+++ b/includes/class-cpt-curator.php
@@ -236,7 +236,7 @@ class CUR_CPT_Curator extends CUR_Singleton {
 	 */	
 	public function run_modules_on_save( $post ) {
 
-		if ( 1 !== did_action( 'save_post' ) ) {
+		if ( 0 == did_action( 'save_post' ) ) {
 			return;
 		}
 

--- a/includes/class-cpt-curator.php
+++ b/includes/class-cpt-curator.php
@@ -236,7 +236,7 @@ class CUR_CPT_Curator extends CUR_Singleton {
 	 */	
 	public function run_modules_on_save( $post ) {
 
-		if ( 0 == did_action( 'save_post' ) ) {
+		if ( 0 === did_action( 'save_post' ) ) {
 			return;
 		}
 

--- a/tests/test-single-site.php
+++ b/tests/test-single-site.php
@@ -279,6 +279,7 @@ class CURTestSingleSite extends CUR_Test_Base {
 		// Simulate Pin item required data and nonce
 		$_POST['cur_curate_item_nonce'] = wp_create_nonce( 'cur_curate_item' );
 		$_POST['cur-pinned-item']       = 'on';
+		$_POST['cur-curated-item']      = 'on';
 
 		$post_id = cur_create_post();
 
@@ -295,7 +296,7 @@ class CURTestSingleSite extends CUR_Test_Base {
 
 
 		$option_slug  = cur_get_pinner_option_slug();
-		$pinned_items = get_option( $option_slug, array() );
+		$pinned_items = get_option( $option_slug );
 
 		// Our new curated post should be on the top of the pinned stack.			
 		$expected = is_array( $pinned_items ) ? $pinned_items[0] : '';


### PR DESCRIPTION
This is from this issue https://github.com/10up/curator/issues/19
@AaronHolbrook  I had to break down  function save_post from curator\includes\class-cpt-curator.php into two as it had grown too coplex. The resulting smaller functions are; save_post and run_modules_on_save please see this commit https://github.com/10up/curator/commit/96998f1c3cfabd02358d91439e275504c43ca868

Then I added the function maybe_update_curated_post which synchronizes the post title between the original post and curated post on save. See commit 
https://github.com/10up/curator/commit/49ca26e3338d9ad131f639276318b29bbca887ca